### PR TITLE
Add customizable "Simple" Haine theme

### DIFF
--- a/src/themes/haine.scss
+++ b/src/themes/haine.scss
@@ -1,4 +1,4 @@
-body[data-theme='simple'] {
+body[data-theme='haine'] {
   // global
   --color-fg: var(--color-theme-foreground);
   --color-bg: var(--color-theme-background);

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -5,6 +5,7 @@ import './default.scss';
 import './horiz.scss';
 import './ikegami.scss';
 import './jround.scss';
+import './simple.scss';
 
 const themes: {[k: string]: Theme} = {
   'default': { text: 'Skyline Overlay', data: { author: authors.DSRKafuU } },
@@ -15,6 +16,14 @@ const themes: {[k: string]: Theme} = {
     data: { author: authors.j0sh77 },
     colors: { background: {r: 0, g: 0, b: 0, a: 0.3} } 
   },
+  simple: {
+    text: 'Simple',
+    colors: {
+      background: {r: 0, g: 0, b: 0, a: 0.3},
+      foreground: {r: 255, g: 255, b: 255, a: 1},
+      border: {r: 255, g: 255, b: 255, a: 1},
+    }
+  }
 };
 
 export default themes;

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -5,7 +5,7 @@ import './default.scss';
 import './horiz.scss';
 import './ikegami.scss';
 import './jround.scss';
-import './simple.scss';
+import './haine.scss';
 
 const themes: {[k: string]: Theme} = {
   'default': { text: 'Skyline Overlay', data: { author: authors.DSRKafuU } },
@@ -16,8 +16,9 @@ const themes: {[k: string]: Theme} = {
     data: { author: authors.j0sh77 },
     colors: { background: {r: 0, g: 0, b: 0, a: 0.3} } 
   },
-  simple: {
-    text: 'Simple',
+  haine: {
+    text: 'Haine',
+    data: { author: authors.j0sh77 },
     colors: {
       background: {r: 0, g: 0, b: 0, a: 0.3},
       foreground: {r: 255, g: 255, b: 255, a: 1},

--- a/src/themes/simple.scss
+++ b/src/themes/simple.scss
@@ -1,0 +1,133 @@
+body[data-theme='simple'] {
+  // global
+  --color-fg: var(--color-theme-foreground);
+  --color-bg: var(--color-theme-background);
+  --shadow: 0 0 0.04rem #000000;
+  --icon-color: var(--color-fg);
+  --icon-shadow: 0 0 0.04rem rgba(0, 0, 0, 0.6);
+  --border-radius: 0.1rem;
+  --border-color: var(--color-theme-border);
+
+  // s-ticker
+  --color-s-ticker-cd: rgba(255, 111, 0, 0.7); // crit direct
+  --color-s-ticker-c: rgba(255, 202, 40, 0.7); // crit
+  --color-s-ticker-d: rgba(29, 233, 182, 0.7); // direct
+  --color-s-ticker-oh: rgba(255, 102, 0, 0.7); // over healed
+  --color-s-ticker-h: rgba(127, 243, 82, 0.8); // healed
+  --color-s-ticker-s: rgba(82, 205, 243, 0.8); // shield
+
+  // combatant
+  --color-combatant-fg: var(--color-fg);
+  --color-combatant-bg-dps: rgba(244, 67, 54, 0.3);
+  --color-combatant-bg-tank: rgba(32, 149, 243, 0.3);
+  --color-combatant-bg-heal: rgba(139, 195, 74, 0.3);
+  --color-combatant-bg-others: var(--color-bg);
+  --color-combatant-bg-self: rgba(0, 0, 0, 0.7);
+  --shadow-combatant: var(--shadow);
+
+  // encounter
+  --color-encounter-fg: var(--color-fg);
+  --color-encounter-bg: var(--color-bg);
+  --color-cover-fg: var(--color-fg);
+  --color-cover-fg-active: var(--color-fg);
+  --color-cover-bg: var(--color-bg);
+  --color-cover-bg-active: var(--color-cover-bg);
+  --shadow-encounter: var(--shadow);
+  --shadow-encounter-active: var(--shadow);
+
+  // settings
+  --color-settings-lowlight: rgba(0, 0, 0, 0.5);
+  --color-settings-highlight: rgba(255, 255, 255, 0.8);
+  --color-settings-fg: var(--color-fg);
+  --color-settings-bg: var(--color-bg);
+  --color-settings-tab-fg: var(--color-fg);
+  --color-settings-tab-bg: var(--color-bg);
+  --color-settings-tab-fg-active: var(--color-fg);
+  --color-settings-tab-bg-active: var(--color-settings-lowlight);
+  --shadow-settings: var(--shadow);
+  --shadow-settings-tab: var(--shadow);
+  --shadow-settings-tab-active: var(--shadow);
+
+  // components
+  --color-form-fg: var(--color-fg);
+  --color-form-fg-active: var(--color-settings-lowlight);
+  --color-form-fg-disabled: rgba(255, 255, 255, 0.7);
+  --color-form-fg-selection: var(--color-fg);
+  --color-form-bg: var(--color-settings-lowlight);
+  --color-form-bg-active: var(--color-settings-highlight);
+  --color-form-bg-disabled: var(--color-form-bg);
+  --color-form-bg-selection: rgba(32, 149, 243, 0.5);
+  --shadow-form: none;
+  --shadow-form-active: none;
+  --shadow-form-selection: none;
+
+  // extends
+  .combatants {
+    .combatant {
+      background-color: var(--color-bg);
+      box-shadow: 0 0 0 0.01rem var(--border-color);
+
+      &-content {
+        background-color: transparent !important;
+      }
+
+      &.jobtype-tank {
+        & .combatant-name {
+          background-color: var(--color-combatant-bg-tank);
+        }
+
+        &.job-self {
+          box-shadow: 0 0 0 0.01rem var(--border-color), 
+            0 0 0 0.04rem var(--color-combatant-bg-tank);
+        }
+      }
+
+      &.jobtype-dps {
+        & .combatant-name {
+          background-color: var(--color-combatant-bg-dps);
+        }
+
+        &.job-self {
+          box-shadow: 0 0 0 0.01rem var(--border-color), 
+            0 0 0 0.04rem var(--color-combatant-bg-dps);
+        }
+      }
+
+      &.jobtype-healer {
+        & .combatant-name {
+          background-color: var(--color-combatant-bg-heal);
+        }
+
+        &.job-self {
+          box-shadow: 0 0 0 0.01rem var(--border-color), 
+            0 0 0 0.04rem var(--color-combatant-bg-heal);
+        }
+      }
+
+      &-detail {
+        box-shadow: 0 0 0 0.01rem var(--border-color);
+      }
+
+      .s-list-section + .s-list-section {
+        border-color: var(--border-color);
+      }
+    }
+  }
+
+  .encounter {
+    margin-top: 0.075rem;
+
+    & > div {
+      box-shadow: 0 0 0 0.01rem var(--border-color);
+    }
+  }
+
+  .settings {
+    box-shadow: 0 0 0 0.01rem var(--border-color);
+    background-color: transparent;
+
+    &-content {
+      background-color: var(--color-settings-bg);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a very simplistic theme that's customizable. It requires https://github.com/dsrkafuu/skyline-overlay/pull/31.

This shows how easy it is to let the user pick what colors they want in their theme. Once the dependent PR is merged, I will open one off of this branch into the parent repo. 

Some examples:
![Capture](https://user-images.githubusercontent.com/5430474/153993853-1363df3b-8324-45f7-b65b-8ef7b9b65937.PNG)
![Capture](https://user-images.githubusercontent.com/5430474/153993927-01fb7d0a-c3c7-4540-9995-1a7a5ea7c4b1.PNG)
![Capture](https://user-images.githubusercontent.com/5430474/153994027-1785b318-df71-4692-af3a-38615ab25ff1.PNG)
![Capture](https://user-images.githubusercontent.com/5430474/153994138-53fa7918-75e2-46a8-ba4b-2bd8bd6dfaa3.PNG)

